### PR TITLE
chore: upgrade Calcit to 0.13.12

### DIFF
--- a/202608121945-upgrade-calcit-01312.md
+++ b/202608121945-upgrade-calcit-01312.md
@@ -1,0 +1,6 @@
+# 升级 Calcit 与 respo-ui
+
+- 从最新 `main` 验证并升级 Calcit 到 0.13.12、`@calcit/procs` 到 0.13.12。
+- 将 respo-ui 依赖更新到 0.7.5，覆盖 `read-field` 对省略 Option 参数的运行时修复。
+- 通过 `cr --check-only`、6 个定义测试、`cr js` 与 Vite 构建验证。
+- 使用浏览器加载 Vite 页面，确认内容正常渲染且本次加载无运行时错误。

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.10)
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.2)
+{} (:calcit-version |0.13.12)
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.5)
     |Respo/respo.calcit |0.16.67

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.8.3",
   "dependencies": {
-    "@calcit/procs": "^0.13.10",
+    "@calcit/procs": "^0.13.12",
     "bottom-tip": "^0.1.5",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.10":
-  version: 0.13.10
-  resolution: "@calcit/procs@npm:0.13.10"
+"@calcit/procs@npm:^0.13.12":
+  version: 0.13.12
+  resolution: "@calcit/procs@npm:0.13.12"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/6352452f00f7a73e071ea0fa944431174cd6da49b2f63ba501c4046ee029dae4b1b0f06a9ef6e59c86492ba2d558af6d51780a2ab50a89ae301772184cad7ea7
+  checksum: 10c0/3d340cc2f7ea8c6094612e26cfd7d15cca79e816ec3da96071ea8519c8e272df8b4e72a2ba9eced15aa8495dfe4f91f4fc937a707a5a7f02fde5afad7579a304
   languageName: node
   linkType: hard
 
@@ -696,7 +696,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.10"
+    "@calcit/procs": "npm:^0.13.12"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.0"


### PR DESCRIPTION
Upgrade from latest main to Calcit 0.13.12 and respo-ui 0.7.5. Verified check-only, all 6 definition tests, JS generation, Vite production build, and browser loading with no new runtime errors. The respo-ui read-field nil-safe fix is now included in 0.7.5.