### PR TITLE
chore: use respo-ui 0.7.6

### DIFF
--- a/202608122000-bump-respo-ui-076.md
+++ b/202608122000-bump-respo-ui-076.md
@@ -1,0 +1,4 @@
+# 使用 respo-ui 0.7.6
+
+- 从最新 main 更新 respo-ui 依赖，确保使用已发布的 nil-safe `read-field` 修复。
+- 通过 `cr --check-only`、6 个定义测试、`cr js` 与 Vite 构建验证。

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
 {} (:calcit-version |0.13.12)
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.5)
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.6)
     |Respo/respo.calcit |0.16.67


### PR DESCRIPTION
Update the dependency to the published respo-ui 0.7.6, which contains the merged nil-safe read-field fix. Verified check-only, all 6 tests, JS generation and Vite build.