### PR TITLE
ci: validate current Calcit project layout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 
-calcit.cirru -diff linguist-generated
 yarn.lock -diff linguist-generated

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -15,7 +15,6 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: 24
-        cache: 'yarn'
 
     - name: Enable Corepack
       run: |
@@ -28,6 +27,11 @@ jobs:
     - name: "compiles to js"
       run: >
         caps --ci && yarn install --immutable
+        && cr calcit.cirru edit format
+        && git diff --exit-code -- calcit.cirru
+        && cr calcit.cirru --check-only
+        && cr calcit.cirru analyze check-types --summary-only --format json
+        && cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
         && cr calcit.cirru test --require-match --summary-only --format json
         && cr calcit.cirru js
         && yarn vite build --base=./

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 .compact-inc.cirru
+compact.cirru
 .calcit-error.cirru
 
 js-out/

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "dayjs": "^1.11.21"
   },
   "scripts": {
-    "test": "cr --emit-js --init-fn=respo-router.test/run-tests --reload-fn=respo-router.test/reload! --once && node test.mjs"
+    "test": "cr calcit.cirru test --require-match --summary-only --format json"
   },
   "devDependencies": {
     "vite": "^8.1.3"
-  }
+  },
+  "packageManager": "yarn@4.12.0"
 }


### PR DESCRIPTION
Completes the current Calcit project upgrade workflow after the 0.13.13 dependency update.

- keeps the canonical single calcit.cirru Snapshot and removes its generated-file diff treatment
- ignores obsolete compact.cirru
- pins Yarn through packageManager and validates Snapshot format/diff, check-only, type coverage, and unresolved weak-type summaries after caps --ci

Validated locally: caps --ci, format/diff, check-only, analyses, 6 tests, JS codegen, and Vite build.