### PR TITLE
chore: upgrade Calcit to 0.13.16

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.13)
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.6)
-    |Respo/respo.calcit |0.16.67
+{} (:calcit-version |0.13.16)
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.7)
+    |Respo/respo.calcit |0.16.70


### PR DESCRIPTION
## Summary
- Upgrade Calcit to 0.13.16, respo to 0.16.70, respo-ui to 0.7.7
- All gates pass: `--check-only` 0 warnings, codegen OK, format stable, 6 tests pass