### PR TITLE
chore: upgrade calcit to 0.13.19

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,4 @@
 
-{} (:calcit-version |0.13.16)
+{} (:calcit-version |0.13.19)
   :dependencies $ {} (|Respo/respo-ui.calcit |0.7.7)
-    |Respo/respo.calcit |0.16.70
-
+    |Respo/respo.calcit |0.16.72

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.8.3",
   "dependencies": {
-    "@calcit/procs": "^0.13.15",
+    "@calcit/procs": "^0.13.19",
     "bottom-tip": "^0.1.5",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.15":
-  version: 0.13.15
-  resolution: "@calcit/procs@npm:0.13.15"
+"@calcit/procs@npm:^0.13.19":
+  version: 0.13.19
+  resolution: "@calcit/procs@npm:0.13.19"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
+  checksum: 10c0/72f17208989f8e2e78462cce625b88fcb5c1635eb04a219f49c954a7c4abc7b0c1bce186d325978a4067d3840e02f3cbf913958828a5a4c543f00bc524c9a9fd
   languageName: node
   linkType: hard
 
@@ -696,7 +696,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.15"
+    "@calcit/procs": "npm:^0.13.19"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.0"


### PR DESCRIPTION
Per `cr docs read upgrade`:
- `caps upgrade --all`: `:calcit-version` -> 0.13.19; pinned deps bumped to latest tags
- `@calcit/procs` synced to ^0.13.19 in package.json / yarn.lock
- modules re-synced via `caps`

deps.cirru audit: all deps pinned to versions; no :dev-dependencies section.