### PR TITLE
chore: upgrade Calcit to 0.13.29

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -35,8 +35,8 @@ jobs:
         && mkdir -p .calcit
         && calcit calcit.cirru analyze check-types --summary-only --format json > .calcit/check-types.json
         && calcit calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json > .calcit/weak-types.json
+        && calcit calcit.cirru analyze deprecated --summary-only --format json > .calcit/deprecated.json
         && node scripts/check-calcit-upgrade-baseline.mjs
-        && calcit calcit.cirru analyze deprecated --summary-only --format json
         && calcit calcit.cirru test --require-match --summary-only --format json
         && calcit calcit.cirru js
         && yarn vite build --base=./

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -22,24 +22,27 @@ jobs:
         corepack prepare yarn@4.12.0 --activate
         yarn --version
 
-    - uses: calcit-lang/setup-cr@0.0.9
+    - uses: calcit-lang/setup-calcit@v1
+      with:
+        tools: calcit,caps
 
     - name: "compiles to js"
       run: >
         caps --ci && yarn install --immutable
-        && cr calcit.cirru edit format
+        && calcit calcit.cirru edit format
         && git diff --exit-code -- calcit.cirru
-        && cr calcit.cirru --check-only
+        && calcit calcit.cirru --check-only
         && mkdir -p .calcit
-        && cr calcit.cirru analyze check-types --summary-only --format json > .calcit/check-types.json
-        && cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json > .calcit/weak-types.json
+        && calcit calcit.cirru analyze check-types --summary-only --format json > .calcit/check-types.json
+        && calcit calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json > .calcit/weak-types.json
         && node scripts/check-calcit-upgrade-baseline.mjs
-        && cr calcit.cirru analyze deprecated --summary-only --format json
-        && cr calcit.cirru test --require-match --summary-only --format json
-        && cr calcit.cirru js
+        && calcit calcit.cirru analyze deprecated --summary-only --format json
+        && calcit calcit.cirru test --require-match --summary-only --format json
+        && calcit calcit.cirru js
         && yarn vite build --base=./
 
     - name: Deploy to server
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: deploy
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -52,4 +55,5 @@ jobs:
         dest: 'rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}'
 
     - name: Display status from deploy
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: echo "${{ steps.deploy.outputs.status }}"

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,10 +1,12 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-router) (:version |0.8.4)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-router)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'respo-router.main/main!) (:mode :native) (:reload-fn 'respo-router.main/reload!)
-      :modules $ [] |respo.calcit/ |respo-ui.calcit/
+      :feature-policy $ {}
+      :modules $ [] |respo.calcit/ |respo-ui.calcit/ |js-ffi/
       :type-slots $ {}
     :test $ {} (:description "|Legacy entry; use cr test for tests") (:init-fn 'respo-router.main/main!) (:mode :native) (:reload-fn 'respo-router.main/reload!)
+      :feature-policy $ {}
       :modules $ [] |respo.calcit/ |respo-ui.calcit/
       :type-slots $ {}
   :files $ {}
@@ -139,7 +141,8 @@
       :defs $ {}
         |dev? $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def dev? $ = |dev (get-env |mode |release)
+            def dev? $ = |dev
+              option:unwrap-or (get-env |mode) |release
           :examples $ []
           :schema $ :: 'Bool
       :ns $ %{} 'NsEntry (:doc |)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,11 +1,11 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-router)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |respo-router)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'respo-router.main/main!) (:mode :native) (:reload-fn 'respo-router.main/reload!)
       :feature-policy $ {}
       :modules $ [] |respo.calcit/ |respo-ui.calcit/ |js-ffi/
       :type-slots $ {}
-    :test $ {} (:description "|Legacy entry; use cr test for tests") (:init-fn 'respo-router.main/main!) (:mode :native) (:reload-fn 'respo-router.main/reload!)
+    :test $ {} (:description "|Legacy entry; use calcit test for tests") (:init-fn 'respo-router.main/main!) (:mode :native) (:reload-fn 'respo-router.main/reload!)
       :feature-policy $ {}
       :modules $ [] |respo.calcit/ |respo-ui.calcit/
       :type-slots $ {}

--- a/config/calcit-upgrade-baseline.json
+++ b/config/calcit-upgrade-baseline.json
@@ -1,11 +1,10 @@
 {
-  "checkTypes": {
-    "levels.none": 29,
-    "levels.partial": 7
-  },
-  "weakTypes": {
-    "hits": 40,
-    "schema-dynamic": 40,
-    "code-dynamic": 0
-  }
+  "typeNone": 29,
+  "typeNotFull": 36,
+  "schemaDynamic": 40,
+  "codeDynamic": 0,
+  "codeNil": 16,
+  "unresolved": 56,
+  "declaredOptional": 0,
+  "deprecatedCalls": 0
 }

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,4 @@
 
-{} (:calcit-version |0.13.16)
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.7)
-    |Respo/respo.calcit |0.16.70
-
+{} (:calcit-version |0.13.27)
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.9)
+    |Respo/respo.calcit |0.16.81

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,5 @@
 
-{} (:calcit-version |0.13.27)
+{} (:calcit-version |0.13.29)
+  :version |0.8.3
   :dependencies $ {} (|Respo/respo-ui.calcit |0.7.9)
     |Respo/respo.calcit |0.16.81

--- a/history/202608221205-upgrade-01329.md
+++ b/history/202608221205-upgrade-01329.md
@@ -1,0 +1,5 @@
+# Calcit 0.13.29 升级
+
+- 将 Calcit、`@calcit/procs`、CI action 与测试/分析命令统一到 0.13.29 / `calcit` / `caps`。
+- 保持 canonical `calcit.cirru`，更新项目版本、依赖与 Yarn lock，并把部署限制在 main push。
+- 本地通过 `caps --ci`、check-only、6 个定义测试、升级 baseline 和 JS codegen；Vite build 需 Node 20.19+ 或 Node 22/24，CI 已使用 Node 24。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.8.3",
   "dependencies": {
-    "@calcit/procs": "^0.13.15",
+    "@calcit/procs": "^0.13.16",
     "bottom-tip": "^0.1.5",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.8.3",
   "dependencies": {
-    "@calcit/procs": "^0.13.16",
+    "@calcit/procs": "^0.13.27",
     "bottom-tip": "^0.1.5",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "version": "0.8.3",
   "dependencies": {
-    "@calcit/procs": "^0.13.27",
+    "@calcit/procs": "^0.13.29",
     "bottom-tip": "^0.1.5",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.0",
     "dayjs": "^1.11.21"
   },
   "scripts": {
-    "test": "cr calcit.cirru test --require-match --summary-only --format json"
+    "test": "calcit calcit.cirru test --require-match --summary-only --format json"
   },
   "devDependencies": {
     "vite": "^8.1.3"

--- a/scripts/check-calcit-upgrade-baseline.mjs
+++ b/scripts/check-calcit-upgrade-baseline.mjs
@@ -1,36 +1,40 @@
 import fs from "node:fs";
 
-const baseline = JSON.parse(fs.readFileSync("config/calcit-upgrade-baseline.json", "utf8"));
-const checkTypes = JSON.parse(fs.readFileSync(".calcit/check-types.json", "utf8")).data.summary;
-const weakTypes = JSON.parse(fs.readFileSync(".calcit/weak-types.json", "utf8")).data.summary;
-
+const read = (name) => {
+  const path = `.calcit/${name}.json`
+  let parsed
+  try { parsed = JSON.parse(fs.readFileSync(path, "utf8")) }
+  catch (error) { throw new Error(`Unable to read ${path}: ${error.message}`) }
+  if (!parsed?.data?.summary) throw new Error(`Missing data.summary in ${path}`)
+  return parsed.data.summary
+}
+const types = read("check-types");
+const weak = read("weak-types");
+const deprecated = read("deprecated");
 const actual = {
-  "levels.none": checkTypes.levels.none,
-  "levels.partial": checkTypes.levels.partial,
-  hits: weakTypes.hits,
-  "schema-dynamic": weakTypes.kinds["schema-dynamic"],
-  "code-dynamic": weakTypes.kinds["code-dynamic"],
+  typeNone: types.levels.none,
+  typeNotFull: types.levels.none + types.levels.partial,
+  schemaDynamic: weak.kinds["schema-dynamic"] ?? 0,
+  codeDynamic: weak.kinds["code-dynamic"] ?? 0,
+  codeNil: weak.kinds["code-nil"] ?? 0,
+  unresolved: weak.intents.unresolved ?? 0,
+  declaredOptional: weak.intents["declared-optional"] ?? 0,
+  deprecatedCalls: deprecated.calls,
 };
-
+const baseline = JSON.parse(fs.readFileSync("config/calcit-upgrade-baseline.json", "utf8"));
 const failures = [];
-const limits = { ...baseline.checkTypes, ...baseline.weakTypes };
-for (const key of Object.keys(limits)) {
-  const limit = limits[key];
-  const value = actual[key];
-  if (typeof limit !== "number" || !Number.isFinite(limit)) {
-    failures.push(`${key}: baseline must be a finite number`);
-  } else if (typeof value !== "number" || !Number.isFinite(value)) {
-    failures.push(`${key}: report value is missing or not numeric`);
-  } else if (value > limit) {
-    failures.push(`${key}: ${value} > ${limit}`);
-  }
-}
 for (const key of Object.keys(actual)) {
-  if (!(key in limits)) failures.push(`${key}: missing baseline metric`);
+  const value = actual[key];
+  const limit = baseline[key];
+  if (!(key in baseline)) failures.push(`${key}: missing baseline metric`);
+  else if (!Number.isFinite(value)) failures.push(`${key}: report value is missing or not numeric`);
+  else if (!Number.isFinite(limit)) failures.push(`${key}: baseline must be a finite number`);
+  else if (value > limit) failures.push(`${key}: ${value} > ${limit}`);
 }
+for (const key of Object.keys(baseline)) if (!(key in actual)) failures.push(`${key}: unknown baseline metric`);
 if (failures.length) {
   console.error("Calcit upgrade baseline exceeded:");
-  for (const failure of failures) console.error(`- ${failure}`);
+  failures.forEach((failure) => console.error(`- ${failure}`));
   process.exit(1);
 }
 console.log("Calcit upgrade baseline passed", actual);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.27":
-  version: 0.13.27
-  resolution: "@calcit/procs@npm:0.13.27"
+"@calcit/procs@npm:^0.13.29":
+  version: 0.13.29
+  resolution: "@calcit/procs@npm:0.13.29"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
+  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
   languageName: node
   linkType: hard
 
@@ -696,7 +696,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.27"
+    "@calcit/procs": "npm:^0.13.29"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.16":
-  version: 0.13.17
-  resolution: "@calcit/procs@npm:0.13.17"
+"@calcit/procs@npm:^0.13.27":
+  version: 0.13.27
+  resolution: "@calcit/procs@npm:0.13.27"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/78a57e550343b147fbecae44d31b09fa8f336dbe1419be42a93802db403ee22e721d3e73129c001b3bbd3a6a681159dc2c19512d7fd2728c875c9b8286b180b8
+  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
   languageName: node
   linkType: hard
 
@@ -696,7 +696,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.16"
+    "@calcit/procs": "npm:^0.13.27"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.15":
-  version: 0.13.15
-  resolution: "@calcit/procs@npm:0.13.15"
+"@calcit/procs@npm:^0.13.16":
+  version: 0.13.17
+  resolution: "@calcit/procs@npm:0.13.17"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
+  checksum: 10c0/78a57e550343b147fbecae44d31b09fa8f336dbe1419be42a93802db403ee22e721d3e73129c001b3bbd3a6a681159dc2c19512d7fd2728c875c9b8286b180b8
   languageName: node
   linkType: hard
 
@@ -696,7 +696,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.15"
+    "@calcit/procs": "npm:^0.13.16"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.0"


### PR DESCRIPTION
本地已使用 Calcit 0.13.27 执行 `cr --check-only` 验证通过。

请等待 Actions 全部通过后再合并。此 PR 不应自动合并。