### PR TITLE
chore: upgrade to Calcit 0.13.51

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
-{} (:calcit-version |0.13.29)
-  :version |0.8.3
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.9)
-    |Respo/respo.calcit |0.16.81
+{} (:calcit-version |0.13.51)
+  :version |0.8.4
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.10)
+    |Respo/respo.calcit |0.16.87

--- a/history/202608271520-upgrade-calcit-01351.md
+++ b/history/202608271520-upgrade-calcit-01351.md
@@ -1,0 +1,5 @@
+# Upgrade to Calcit 0.13.51
+
+- Release respo-router 0.8.4 with Respo 0.16.87 strict macro contracts.
+- Align the JavaScript runtime package with the Calcit CLI release.
+- Verify the resolved dependency graph has no legacy macro schemas.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.8.3",
   "dependencies": {
-    "@calcit/procs": "^0.13.29",
+    "@calcit/procs": "0.13.51",
     "bottom-tip": "^0.1.5",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.29":
-  version: 0.13.29
-  resolution: "@calcit/procs@npm:0.13.29"
+"@calcit/procs@npm:0.13.51":
+  version: 0.13.51
+  resolution: "@calcit/procs@npm:0.13.51"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
+  checksum: 10c0/a83022d613374aac8e648ff9213a011d18ffe204607fece9ba9d7bccbc022e09eb028dbb74589a3c2a7c5aeeb76eb368f058d08d072b9ca4ad45fc4693cdfa00
   languageName: node
   linkType: hard
 
@@ -696,7 +696,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.29"
+    "@calcit/procs": "npm:0.13.51"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.0"


### PR DESCRIPTION
Release respo-router 0.8.4 with Calcit and @calcit/procs 0.13.51, Respo 0.16.87, and Respo UI 0.7.10.\n\nValidation: formatting, check-only, dependency-aware legacy macro inventory = 0, weak/deprecated analysis baseline, 6/6 tests, JS codegen, Vite production build, and immutable install.