### PR TITLE
chore: release 0.8.6

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
 {} (:calcit-version |0.13.51)
-  :version |0.8.4
+  :version |0.8.6
   :dependencies $ {} (|Respo/respo-ui.calcit |0.7.10)
     |Respo/respo.calcit |0.16.87

--- a/history/202608271520-upgrade-calcit-01351.md
+++ b/history/202608271520-upgrade-calcit-01351.md
@@ -1,5 +1,5 @@
 # Upgrade to Calcit 0.13.51
 
-- Release respo-router 0.8.4 with Respo 0.16.87 strict macro contracts.
+- Release respo-router 0.8.6 with Respo 0.16.87 strict macro contracts.
 - Align the JavaScript runtime package with the Calcit CLI release.
 - Verify the resolved dependency graph has no legacy macro schemas.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.3",
+  "version": "0.8.6",
   "dependencies": {
     "@calcit/procs": "0.13.51",
     "bottom-tip": "^0.1.5",


### PR DESCRIPTION
Correct the release version after discovering that 0.8.4 and 0.8.5 were already published. Keep package.json and deps.cirru aligned at the next available version, 0.8.6.\n\nThe Calcit 0.13.51, @calcit/procs 0.13.51, Respo 0.16.87 migration from #26 remains unchanged and validated.